### PR TITLE
fix: 简化心跳事件的推送逻辑，去掉二次channel传递 (#975)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.1
+          go-version: 1.19
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,7 +29,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go-version: [ 1.17.x ]
+        go-version: [ 1.19 ]
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration-testing-mysql.yml
+++ b/.github/workflows/integration-testing-mysql.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.1
+          go-version: 1.19
       # Checkout latest code
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.1
+          go-version: 1.19
 
       - name: Get version
         id: get_version

--- a/apiserver/eurekaserver/write_test.go
+++ b/apiserver/eurekaserver/write_test.go
@@ -28,13 +28,14 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	api "github.com/polarismesh/polaris/common/api/v1"
+	"github.com/polarismesh/polaris/common/eventhub"
 	"github.com/polarismesh/polaris/common/model"
 	"github.com/polarismesh/polaris/common/utils"
 	"github.com/polarismesh/polaris/store/mock"
 )
 
 func TestEurekaServer_renew(t *testing.T) {
-
+	eventhub.InitEventHub()
 	ins := &model.Instance{
 		ServiceID: utils.NewUUID(),
 		Proto: &apiservice.Instance{

--- a/common/eventhub/eventhub_test.go
+++ b/common/eventhub/eventhub_test.go
@@ -58,12 +58,9 @@ func TestEventHub_Publish(t *testing.T) {
 		{
 			name: "publish event",
 			args: args{
-				topic: "test1",
-				name:  "subscribe1",
-				handler: func(ctx context.Context, i interface{}) error {
-					fmt.Printf("handle event=%v\n", i)
-					return nil
-				},
+				topic:    "test1",
+				name:     "subscribe1",
+				handler:  &printEventHandler{},
 				eventNum: 100,
 			},
 		},
@@ -83,6 +80,20 @@ func TestEventHub_Publish(t *testing.T) {
 	}
 }
 
+type printEventHandler struct {
+}
+
+// PreProcess do preprocess logic for event
+func (p *printEventHandler) PreProcess(ctx context.Context, value any) any {
+	return value
+}
+
+// OnEvent event process logic
+func (p *printEventHandler) OnEvent(ctx context.Context, any2 any) error {
+	fmt.Printf("handle event=%v", any2)
+	return nil
+}
+
 func TestEventHub_Subscribe(t *testing.T) {
 	type args struct {
 		topic   string
@@ -98,13 +109,10 @@ func TestEventHub_Subscribe(t *testing.T) {
 		{
 			name: "subscribe topic",
 			args: args{
-				topic: "test2",
-				name:  "subscribe2",
-				handler: func(ctx context.Context, i interface{}) error {
-					fmt.Printf("handle event=%v", i)
-					return nil
-				},
-				opts: []SubOption{WithQueueSize(100)},
+				topic:   "test2",
+				name:    "subscribe2",
+				handler: &printEventHandler{},
+				opts:    []SubOption{WithQueueSize(100)},
 			},
 			wantErr: nil,
 		},
@@ -132,12 +140,9 @@ func TestEventHub_Unsubscribe(t *testing.T) {
 		{
 			name: "unsubscribe topic",
 			args: args{
-				topic: "test3",
-				name:  "subscribe3",
-				handler: func(ctx context.Context, i interface{}) error {
-					fmt.Printf("handle event=%v\n", i)
-					return nil
-				},
+				topic:   "test3",
+				name:    "subscribe3",
+				handler: &printEventHandler{},
 			},
 			wantErr: nil,
 		},

--- a/common/eventhub/topic_test.go
+++ b/common/eventhub/topic_test.go
@@ -19,7 +19,6 @@ package eventhub
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,13 +98,10 @@ func Test_topic_subscribe(t *testing.T) {
 		{
 			name: "topic subscribe",
 			args: args{
-				ctx:  context.Background(),
-				name: "sub1",
-				handler: func(ctx context.Context, i interface{}) error {
-					fmt.Printf("handle event=%v\n", i)
-					return nil
-				},
-				opts: []SubOption{WithQueueSize(100)},
+				ctx:     context.Background(),
+				name:    "sub1",
+				handler: &printEventHandler{},
+				opts:    []SubOption{WithQueueSize(100)},
 			},
 			wantErr: nil,
 		},
@@ -135,12 +131,9 @@ func Test_topic_unsubscribe(t *testing.T) {
 		{
 			name: "topic unsubscribe",
 			args: args{
-				ctx:  context.Background(),
-				name: "sub1",
-				handler: func(ctx context.Context, i interface{}) error {
-					fmt.Printf("handle event=%v\n", i)
-					return nil
-				},
+				ctx:     context.Background(),
+				name:    "sub1",
+				handler: &printEventHandler{},
 			},
 			wantErr: nil,
 		},
@@ -171,14 +164,11 @@ func Test_topic_run(t *testing.T) {
 		{
 			name: "topic run",
 			args: args{
-				ctx:  context.Background(),
-				name: "sub1",
-				handler: func(ctx context.Context, i interface{}) error {
-					fmt.Printf("handle event=%v\n", i)
-					return nil
-				},
-				opts: []SubOption{WithQueueSize(100)},
-				num:  100,
+				ctx:     context.Background(),
+				name:    "sub1",
+				handler: &printEventHandler{},
+				opts:    []SubOption{WithQueueSize(100)},
+				num:     100,
 			},
 		},
 	}

--- a/common/model/instance_event.go
+++ b/common/model/instance_event.go
@@ -53,6 +53,7 @@ const CtxEventKeyMetadata = "ctx_event_metadata"
 // InstanceEvent 服务实例事件
 type InstanceEvent struct {
 	Id         string
+	SvcId      string
 	Namespace  string
 	Service    string
 	Instance   *apiservice.Instance
@@ -75,6 +76,6 @@ func (i *InstanceEvent) String() string {
 		return "nil"
 	}
 	hostPortStr := fmt.Sprintf("%s:%d", i.Instance.GetHost().GetValue(), i.Instance.GetPort().GetValue())
-	return fmt.Sprintf("InstanceEvent(id=%s, namespace=%s, service=%s, type=%v, instance=%s, healthy=%v)",
-		i.Id, i.Namespace, i.Service, i.EType, hostPortStr, i.Instance.GetHealthy().GetValue())
+	return fmt.Sprintf("InstanceEvent(id=%s, namespace=%s, svcId=%s, service=%s, type=%v, instance=%s, healthy=%v)",
+		i.Id, i.Namespace, i.SvcId, i.Service, i.EType, hostPortStr, i.Instance.GetHealthy().GetValue())
 }

--- a/service/event.go
+++ b/service/event.go
@@ -1,0 +1,69 @@
+/**
+ * Tencent is pleased to support the open source community by making Polaris available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/polarismesh/polaris/common/model"
+)
+
+type serviceNameResolver func(string) *model.Service
+
+const maxRetryGetServiceName = 5
+
+type BaseInstanceEventHandler struct {
+	namingServer DiscoverServer
+	svcResolver  serviceNameResolver
+}
+
+func NewBaseInstanceEventHandler(namingServer DiscoverServer) *BaseInstanceEventHandler {
+	eventHandler := &BaseInstanceEventHandler{namingServer: namingServer}
+	eventHandler.svcResolver = eventHandler.resolveService
+	return eventHandler
+}
+
+func (b *BaseInstanceEventHandler) resolveService(svcId string) *model.Service {
+	return b.namingServer.Cache().Service().GetServiceByID(svcId)
+}
+
+// PreProcess do preprocess logic for event
+func (b *BaseInstanceEventHandler) PreProcess(ctx context.Context, value any) any {
+	instEvent, ok := value.(model.InstanceEvent)
+	if !ok {
+		return value
+	}
+	b.resolveServiceName(&instEvent)
+	return instEvent
+}
+
+func (b *BaseInstanceEventHandler) resolveServiceName(event *model.InstanceEvent) {
+	if len(event.Service) == 0 && len(event.SvcId) > 0 {
+		for i := 0; i < maxRetryGetServiceName; i++ {
+			svcObject := b.svcResolver(event.SvcId)
+			if nil == svcObject {
+				time.Sleep(500 * time.Millisecond)
+				continue
+			}
+			event.Service = svcObject.Name
+			event.Namespace = svcObject.Namespace
+			break
+		}
+	}
+}

--- a/service/event_test.go
+++ b/service/event_test.go
@@ -1,0 +1,54 @@
+/**
+ * Tencent is pleased to support the open source community by making Polaris available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/polarismesh/polaris/common/model"
+)
+
+func TestPreProcess(t *testing.T) {
+	svcId := "1234"
+	mockSvc := &model.Service{
+		ID:        svcId,
+		Namespace: DefaultNamespace,
+		Name:      "testSvc",
+	}
+	svr := &BaseInstanceEventHandler{svcResolver: func(s string) *model.Service {
+		if s == svcId {
+			return mockSvc
+		}
+		return nil
+	}}
+	event := model.InstanceEvent{SvcId: svcId}
+	event0bj := svr.PreProcess(context.Background(), event)
+	eventNext := event0bj.(model.InstanceEvent)
+	assert.Equal(t, mockSvc.Namespace, eventNext.Namespace)
+	assert.Equal(t, mockSvc.Name, eventNext.Service)
+
+	event = model.InstanceEvent{SvcId: "xyz"}
+	event0bj = svr.PreProcess(context.Background(), event)
+	eventNext = event0bj.(model.InstanceEvent)
+	assert.Equal(t, "", eventNext.Namespace)
+	assert.Equal(t, "", eventNext.Service)
+
+}

--- a/service/healthcheck/leader.go
+++ b/service/healthcheck/leader.go
@@ -46,8 +46,13 @@ func newLeaderChangeEventHandler(cacheProvider *CacheProvider,
 	}
 }
 
-// checkSelfServiceInstances
-func (handler *LeaderChangeEventHandler) handle(ctx context.Context, i interface{}) error {
+// PreProcess do preprocess logic for event
+func (handler *LeaderChangeEventHandler) PreProcess(ctx context.Context, value any) any {
+	return value
+}
+
+// OnEvent event trigger
+func (handler *LeaderChangeEventHandler) OnEvent(ctx context.Context, i interface{}) error {
 	e := i.(store.LeaderChangeEvent)
 	if e.Key != store.ELECTION_KEY_SELF_SERVICE_CHECKER {
 		return nil

--- a/service/healthcheck/test_export.go
+++ b/service/healthcheck/test_export.go
@@ -74,9 +74,6 @@ func TestInitialize(ctx context.Context, hcOpt *Config, cacheOpen bool, bc *batc
 		hcOpt.MaxCheckInterval, hcOpt.ClientCheckInterval, hcOpt.ClientCheckTtl)
 	testServer.dispatcher = newDispatcher(ctx, testServer, hcOpt.OmitReplicated)
 
-	testServer.discoverCh = make(chan eventWrapper, 32)
-	go testServer.receiveEventAndPush()
-
 	finishInit = true
 
 	return testServer, nil


### PR DESCRIPTION
* fix: eureka updateStatus鉴权失败

* fix：db integrate test run failed

* fix: database deadlock issues

* fix: all write db operation should be in transaction

* fix: group not in tx

* feat：增加串行创建实例的覆盖

* feat：remove ListNamespaces refer

* fix: 解决不在同一个事务的问题

* feat: 迁移工具支持环境变量传参，以及打印日志

* feat: eureka创建和删除实例使用异步处理

* feat：解决首次注册后心跳上报失败的问题 & 针对复制的实例可以允许关闭健康状态的转换

* feat：修复实例多次后404的问题

* fix: 修复用例失败问题

* fix: 简化心跳事件的推送逻辑，去掉二次channel传递

* fix: 将服务名转换提取成公共逻辑

* feat：event用例调整

* feat: update go version

* fix：ut fail issues

* fix: 用例失败问题

**Please provide issue(s) of this PR:**
Fixes #

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] ApiServer
- [ ] Auth
- [ ] Configuration
- [ ] Naming
- [ ] HealthCheck
- [ ] Metrics
- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
